### PR TITLE
Storing interest calculation options in url

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"react-dnd": "^16.0.1",
 		"react-dnd-html5-backend": "^16.0.1",
 		"react-dom": "^18.1.0",
-		"react-hook-form": "^7.3.6",
+		"react-hook-form": "^7.31.3",
 		"react-icons": "^4.2.0",
 		"react-number-format": "^4.5.5",
 		"react-spring": "^9.1.2",

--- a/pages/interest.tsx
+++ b/pages/interest.tsx
@@ -4,7 +4,7 @@ import CompoundInterest from 'features/CompoundInterest';
 
 const CompoundInterestCalculatorPage: React.FC = () => (
 	<>
-		<SEO title="Compound Interest calculator" />
+		<SEO title="Interest calculator" />
 		<CompoundInterest />
 	</>
 );

--- a/src/features/CompoundInterest/AmountSummaryProps.tsx
+++ b/src/features/CompoundInterest/AmountSummaryProps.tsx
@@ -1,0 +1,20 @@
+import React, { FC } from 'react';
+import { formatter } from './index';
+
+interface AmountSummaryProps {
+	amount: number;
+	label: string;
+	color?: string;
+}
+
+const AmountSummary: FC<AmountSummaryProps> = ({ amount, label, color }) => (
+	<div className="flex space-x-4">
+		<div className={`h-6 w-6 rounded-full ${color}`}></div>
+		<div>
+			<span className="text-black dark:text-gray-300">{label}</span>
+			<div className="text-2xl text-black dark:text-white">{formatter.format(amount)}</div>
+		</div>
+	</div>
+);
+
+export default AmountSummary;

--- a/src/features/CompoundInterest/CalculationSummary.tsx
+++ b/src/features/CompoundInterest/CalculationSummary.tsx
@@ -1,0 +1,104 @@
+import React, { useMemo } from 'react';
+import { FV } from 'services/formulas';
+import AmountSummary from './AmountSummaryProps';
+import { formatter, FormData } from './index';
+
+const CalculationSummary: React.FC<FormData> = props => {
+	const rate = useMemo(() => props.interestRate / 100, [props.interestRate]);
+	const isWithDeposits = useMemo(() => props.monthlyDeposit !== 0, [props.monthlyDeposit]);
+
+	const balance = FV(props.existingAmount, props.monthlyDeposit, rate, props.investmentPeriod);
+	const totalDeposits = 12 * props.monthlyDeposit * props.investmentPeriod + props.existingAmount;
+	const totalInterest = balance - totalDeposits;
+
+	return (
+		<>
+			<div className="flex w-full flex-col items-center">
+				<div className="grid w-full max-w-2xl grid-cols-1 justify-center gap-y-4 gap-x-8 p-8 md:grid-cols-2">
+					<AmountSummary
+						amount={balance}
+						label={`Balance after ${props.investmentPeriod} years`}
+						color="bg-blue-900 dark:bg-blue-300"
+					/>
+					<AmountSummary
+						amount={props.existingAmount}
+						label={`Initial amount`}
+						color="bg-green-900 dark:bg-green-300"
+					/>
+					<AmountSummary
+						amount={totalDeposits}
+						label={`Total deposits`}
+						color="bg-indigo-900 dark:bg-indigo-300"
+					/>
+					<AmountSummary
+						amount={totalInterest}
+						label={'Gain from interest'}
+						color="bg-yellow-900 dark:bg-yellow-300"
+					/>
+				</div>
+			</div>
+			<div className="-mx-4 overflow-x-scroll lg:m-0 lg:w-full lg:overflow-x-auto">
+				<table className="w-full">
+					<TableHeader isWithDeposits={isWithDeposits} />
+					<tbody className="text-right font-mono">
+						{[...Array(props.investmentPeriod + 1).keys()].map(year => (
+							<TableRow
+								key={year}
+								{...props}
+								year={year}
+								rate={rate}
+								isWithDeposits={isWithDeposits}
+							/>
+						))}
+					</tbody>
+				</table>
+			</div>
+		</>
+	);
+};
+
+export default CalculationSummary;
+
+const TableHeader: React.FC<{ isWithDeposits: boolean }> = ({ isWithDeposits }) => (
+	<thead>
+		<tr className="text-right">
+			<th className="px-4 text-center">Year</th>
+			{isWithDeposits && <th className="px-4">Deposit</th>}
+			<th className="px-4 text-green-800 dark:text-green-400">Interest</th>
+			{isWithDeposits && <th className="px-4">Total deposits</th>}
+			<th className="px-4 text-purple-800 dark:text-purple-400">Total interest</th>
+			<th className="px-4 text-red-800 dark:text-red-400">Balance</th>
+		</tr>
+	</thead>
+);
+
+interface TableRowProps extends FormData {
+	year: number;
+	rate: number;
+	isWithDeposits: boolean;
+}
+
+const TableRow: React.FC<TableRowProps> = props => {
+	const { rate, year, isWithDeposits } = props;
+	const deposit = year === 0 ? props.existingAmount : 12 * props.monthlyDeposit;
+	const totalDeposit = year * 12 * props.monthlyDeposit + props.existingAmount;
+	const totalBalance = FV(props.existingAmount, props.monthlyDeposit, rate, year);
+	const lastYear = year - 1;
+
+	const depositPrevious = lastYear * 12 * props.monthlyDeposit + props.existingAmount;
+	const balancePrevious = FV(props.existingAmount, props.monthlyDeposit, rate, lastYear);
+
+	const totalInterest = totalBalance - totalDeposit;
+	const interest = year === 0 ? 0 : totalInterest - (balancePrevious - depositPrevious);
+
+	return (
+		<tr key={year} className="odd:bg-gray-200 dark:odd:bg-gray-900">
+			<td className="px-4 text-center">{year}</td>
+			{isWithDeposits && <td className="px-4">{formatter.format(deposit)}</td>}
+			<td className="px-4">{formatter.format(interest)}</td>
+			{isWithDeposits && <td className="px-4">{formatter.format(totalDeposit)}</td>}
+			<td className="px-4">{formatter.format(totalInterest)}</td>
+			<td className="px-4">{formatter.format(totalBalance)}</td>
+		</tr>
+	);
+};

--- a/src/features/CompoundInterest/CalculationSummary.tsx
+++ b/src/features/CompoundInterest/CalculationSummary.tsx
@@ -37,7 +37,7 @@ const CalculationSummary: React.FC<FormData> = props => {
 					/>
 				</div>
 			</div>
-			<div className="-mx-4 overflow-x-scroll lg:m-0 lg:w-full lg:overflow-x-auto">
+			<div className="overflow-x-scroll lg:m-0 lg:w-full lg:overflow-x-auto">
 				<table className="w-full">
 					<TableHeader isWithDeposits={isWithDeposits} />
 					<tbody className="text-right font-mono">
@@ -48,6 +48,7 @@ const CalculationSummary: React.FC<FormData> = props => {
 								year={year}
 								rate={rate}
 								isWithDeposits={isWithDeposits}
+								isLastRow={year === props.investmentPeriod}
 							/>
 						))}
 					</tbody>
@@ -59,15 +60,24 @@ const CalculationSummary: React.FC<FormData> = props => {
 
 export default CalculationSummary;
 
+const typeColors = {
+	deposit: 'text-teal-800 dark:text-teal-400',
+	interest: 'text-green-800 dark:text-green-400',
+	totalDeposit: 'text-orange-800 dark:text-orange-400',
+	totalInterest: 'text-purple-800 dark:text-purple-400',
+	balance: 'text-red-800 dark:text-red-400',
+};
+
 const TableHeader: React.FC<{ isWithDeposits: boolean }> = ({ isWithDeposits }) => (
 	<thead>
 		<tr className="text-right">
 			<th className="px-4 text-center">Year</th>
-			{isWithDeposits && <th className="px-4">Deposit</th>}
-			<th className="px-4 text-green-800 dark:text-green-400">Interest</th>
-			{isWithDeposits && <th className="px-4">Total deposits</th>}
-			<th className="px-4 text-purple-800 dark:text-purple-400">Total interest</th>
-			<th className="px-4 text-red-800 dark:text-red-400">Balance</th>
+			{isWithDeposits && <th className={`px-4 ${typeColors.deposit}`}>Deposit</th>}
+			<th className={`px-4 ${typeColors.interest}`}>Interest</th>
+			{isWithDeposits && <th className={`px-4 ${typeColors.totalDeposit}`}>Total deposits</th>}
+			<th className={`px-4 ${typeColors.totalInterest}`}>Total interest</th>
+			<th className={`px-4 ${typeColors.balance}`}>Balance</th>
+			<th className="px-4">Date</th>
 		</tr>
 	</thead>
 );
@@ -76,10 +86,11 @@ interface TableRowProps extends FormData {
 	year: number;
 	rate: number;
 	isWithDeposits: boolean;
+	isLastRow: boolean;
 }
 
 const TableRow: React.FC<TableRowProps> = props => {
-	const { rate, year, isWithDeposits } = props;
+	const { rate, year, isWithDeposits, isLastRow } = props;
 	const deposit = year === 0 ? props.existingAmount : 12 * props.monthlyDeposit;
 	const totalDeposit = year * 12 * props.monthlyDeposit + props.existingAmount;
 	const totalBalance = FV(props.existingAmount, props.monthlyDeposit, rate, year);
@@ -94,11 +105,31 @@ const TableRow: React.FC<TableRowProps> = props => {
 	return (
 		<tr key={year} className="odd:bg-gray-200 dark:odd:bg-gray-900">
 			<td className="px-4 text-center">{year}</td>
-			{isWithDeposits && <td className="px-4">{formatter.format(deposit)}</td>}
-			<td className="px-4">{formatter.format(interest)}</td>
-			{isWithDeposits && <td className="px-4">{formatter.format(totalDeposit)}</td>}
-			<td className="px-4">{formatter.format(totalInterest)}</td>
-			<td className="px-4">{formatter.format(totalBalance)}</td>
+			{isWithDeposits && (
+				<td className={`px-4 ${isLastRow ? typeColors.deposit : ''}`.trim()}>
+					{formatter.format(deposit)}
+				</td>
+			)}
+			<td className={`px-4 ${isLastRow ? typeColors.interest : ''}`.trim()}>
+				{formatter.format(interest)}
+			</td>
+			{isWithDeposits && (
+				<td className={`px-4 ${isLastRow ? typeColors.totalDeposit : ''}`.trim()}>
+					{formatter.format(totalDeposit)}
+				</td>
+			)}
+			<td className={`px-4 ${isLastRow ? typeColors.totalInterest : ''}`.trim()}>
+				{formatter.format(totalInterest)}
+			</td>
+			<td className={`px-4 ${isLastRow ? typeColors.balance : ''}`.trim()}>
+				{formatter.format(totalBalance)}
+			</td>
+			<td className="px-4">{addYears(new Date(), year).toLocaleDateString()}</td>
 		</tr>
 	);
 };
+
+function addYears(date: Date, years: number): Date {
+	date.setFullYear(date.getFullYear() + years);
+	return date;
+}

--- a/src/features/CompoundInterest/index.tsx
+++ b/src/features/CompoundInterest/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Button, Input, Select, SelectOption } from '@oliverflecke/components-react';
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import NumberFormat from 'react-number-format';
 import { InterestAccrual } from 'services/formulas';
@@ -47,6 +47,12 @@ const CompoundInterest: FC<CompoundInterestProps> = () => {
 
 		setData(data);
 	});
+
+	const resetForm = useCallback(() => {
+		const url = new URL(window.location.href);
+		url.search = '';
+		window.location.href = url.toString();
+	}, []);
 
 	return (
 		<div className="pb-4 dark:bg-gray-800">
@@ -119,8 +125,11 @@ const CompoundInterest: FC<CompoundInterestProps> = () => {
 						})}
 					/>
 				</fieldset>
-				<div className="flex w-full justify-center pt-4">
+				<div className="flex w-full justify-center space-x-4 pt-4">
 					<Button type="submit">Calculate</Button>
+					<Button type="reset" buttonType="Secondary" onClick={resetForm}>
+						Reset
+					</Button>
 				</div>
 			</form>
 			{data && (

--- a/src/features/CompoundInterest/index.tsx
+++ b/src/features/CompoundInterest/index.tsx
@@ -43,6 +43,7 @@ const CompoundInterest: FC<CompoundInterestProps> = ({}: CompoundInterestProps) 
 					<Input
 						label="Expected yearly growth"
 						placeholder="7"
+						className="dark:placeholder-gray-600"
 						errorMessage={errors.interestRate?.message}
 						{...register('interestRate', {
 							required: 'Please provide a valid value',
@@ -51,6 +52,7 @@ const CompoundInterest: FC<CompoundInterestProps> = ({}: CompoundInterestProps) 
 					<Input
 						label="Investment period"
 						placeholder="10"
+						className="dark:placeholder-gray-600"
 						errorMessage={errors.investmentPeriod?.message}
 						{...register('investmentPeriod', {
 							required: 'Please provide a number of years you are investing',
@@ -69,6 +71,7 @@ const CompoundInterest: FC<CompoundInterestProps> = ({}: CompoundInterestProps) 
 						label="Monthly deposit"
 						placeholder="10,000"
 						inputMode="numeric"
+						className="dark:placeholder-gray-600"
 						errorMessage={errors.monthlyDeposit?.message}
 						{...register('monthlyDeposit', {
 							required: 'Please provide how much you will deposit each month',

--- a/src/features/CompoundInterest/index.tsx
+++ b/src/features/CompoundInterest/index.tsx
@@ -1,14 +1,15 @@
 import { Button, Input, Select, SelectOption } from '@oliverflecke/components-react';
-import React, { FC, useMemo, useState } from 'react';
+import React, { FC, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { FV, InterestAccrual } from '../../services/formulas';
-import { parseNumber } from '../../utils/converters';
+import { InterestAccrual } from 'services/formulas';
+import { parseNumber } from 'utils/converters';
+import CalculationSummary from './CalculationSummary';
 
 interface CompoundInterestProps {
 	name?: string;
 }
 
-type FormData = {
+export type FormData = {
 	existingAmount: number;
 	interestRate: number;
 	investmentPeriod: number;
@@ -23,16 +24,13 @@ const CompoundInterest: FC<CompoundInterestProps> = ({}: CompoundInterestProps) 
 		handleSubmit,
 		formState: { errors },
 	} = useForm<FormData>({});
-	const onSubmit = handleSubmit((d) => {
-		console.debug(d);
-		setData(d);
-	});
+	const onSubmit = handleSubmit(d => setData(d));
 
 	return (
 		<div className="pb-4 dark:bg-gray-800">
-			<h2 className="text-xl px-4 py-4 lg:text-left">Compound interest calculator</h2>
-			<form onSubmit={onSubmit} className="w-full px-4 overflow-x-hidden flex-col-center">
-				<fieldset className="flex flex-col items-start space-y-6 sm:space-y-0 sm:grid sm:grid-cols-3 sm:gap-6">
+			<h2 className="px-4 py-4 text-xl lg:text-left">Compound interest calculator</h2>
+			<form onSubmit={onSubmit} className="flex-col-center w-full overflow-x-hidden px-4">
+				<fieldset className="flex flex-col items-start space-y-6 sm:grid sm:grid-cols-3 sm:gap-6 sm:space-y-0">
 					<Input
 						// customInput={Input}
 						// thousandSeparator={true}
@@ -77,7 +75,7 @@ const CompoundInterest: FC<CompoundInterestProps> = ({}: CompoundInterestProps) 
 						})}
 					/>
 				</fieldset>
-				<div className="w-full pt-4 flex justify-center">
+				<div className="flex w-full justify-center pt-4">
 					<Button type="submit">Calculate</Button>
 				</div>
 			</form>
@@ -96,99 +94,7 @@ const CompoundInterest: FC<CompoundInterestProps> = ({}: CompoundInterestProps) 
 
 export default CompoundInterest;
 
-const formatter = Intl.NumberFormat('en-US', {
+export const formatter = Intl.NumberFormat('en-US', {
 	style: 'currency',
 	currency: 'DKK',
 });
-
-const CalculationSummary = (props: FormData) => {
-	const r = useMemo(() => props.interestRate / 100, [props.interestRate]);
-	const isWithDeposits = useMemo(() => props.monthlyDeposit !== 0, [props.monthlyDeposit]);
-
-	const balance = FV(props.existingAmount, props.monthlyDeposit, r, props.investmentPeriod);
-	const totalDeposits = 12 * props.monthlyDeposit * props.investmentPeriod + props.existingAmount;
-	const totalInterest = balance - totalDeposits;
-
-	return (
-		<>
-			<div className="w-full flex flex-col items-center">
-				<div className="max-w-2xl w-full grid grid-cols-1 gap-y-4 gap-x-8 md:grid-cols-2 justify-center p-8">
-					<AmountSummary
-						amount={balance}
-						label={`Balance after ${props.investmentPeriod} years`}
-						color="bg-blue-900 dark:bg-blue-300"
-					/>
-					<AmountSummary
-						amount={props.existingAmount}
-						label={`Initial amount`}
-						color="bg-green-900 dark:bg-green-300"
-					/>
-					<AmountSummary
-						amount={totalDeposits}
-						label={`Total deposits`}
-						color="bg-indigo-900 dark:bg-indigo-300"
-					/>
-					<AmountSummary
-						amount={totalInterest}
-						label={'Gain from interest'}
-						color="bg-yellow-900 dark:bg-yellow-300"
-					/>
-				</div>
-			</div>
-			<div className="overflow-x-scroll -mx-4 lg:overflow-x-auto lg:w-full lg:m-0">
-				<table className="w-full">
-					<thead>
-						<tr className="text-right">
-							<th className="px-4 text-center">Year</th>
-							{isWithDeposits && <th className="px-4">Deposit</th>}
-							<th className="px-4 text-green-800 dark:text-green-400">Interest</th>
-							{isWithDeposits && <th className="px-4">Total deposits</th>}
-							<th className="px-4 text-purple-800 dark:text-purple-400">Total interest</th>
-							<th className="px-4 text-red-800 dark:text-red-400">Balance</th>
-						</tr>
-					</thead>
-					<tbody className="text-right font-mono">
-						{[...Array(props.investmentPeriod + 1).keys()].map((year) => {
-							const deposit = year === 0 ? props.existingAmount : 12 * props.monthlyDeposit;
-							const totalDeposit = year * 12 * props.monthlyDeposit + props.existingAmount;
-							const totalBalance = FV(props.existingAmount, props.monthlyDeposit, r, year);
-							const lastYear = year - 1;
-
-							const depositPrevious = lastYear * 12 * props.monthlyDeposit + props.existingAmount;
-							const balancePrevious = FV(props.existingAmount, props.monthlyDeposit, r, lastYear);
-
-							const totalInterest = totalBalance - totalDeposit;
-							const interest = year === 0 ? 0 : totalInterest - (balancePrevious - depositPrevious);
-
-							return (
-								<tr key={year} className="odd:bg-gray-200 dark:odd:bg-gray-900">
-									<td className="text-center px-4">{year}</td>
-									{isWithDeposits && <td className="px-4">{formatter.format(deposit)}</td>}
-									<td className="px-4">{formatter.format(interest)}</td>
-									{isWithDeposits && <td className="px-4">{formatter.format(totalDeposit)}</td>}
-									<td className="px-4">{formatter.format(totalInterest)}</td>
-									<td className="px-4">{formatter.format(totalBalance)}</td>
-								</tr>
-							);
-						})}
-					</tbody>
-				</table>
-			</div>
-		</>
-	);
-};
-
-type AmountSummaryProps = {
-	amount: number;
-	label: string;
-	color?: string;
-};
-const AmountSummary: FC<AmountSummaryProps> = ({ amount, label, color }: AmountSummaryProps) => (
-	<div className="flex space-x-4">
-		<div className={`w-6 h-6 rounded-full ${color}`}></div>
-		<div>
-			<span className="text-black dark:text-gray-300">{label}</span>
-			<div className="text-black dark:text-white text-2xl">{formatter.format(amount)}</div>
-		</div>
-	</div>
-);

--- a/src/features/CompoundInterest/index.tsx
+++ b/src/features/CompoundInterest/index.tsx
@@ -4,6 +4,7 @@ import { useForm } from 'react-hook-form';
 import { InterestAccrual } from 'services/formulas';
 import { parseNumber } from 'utils/converters';
 import CalculationSummary from './CalculationSummary';
+import NumberFormat from 'react-number-format';
 
 interface CompoundInterestProps {
 	name?: string;
@@ -23,21 +24,32 @@ const CompoundInterest: FC<CompoundInterestProps> = ({}: CompoundInterestProps) 
 		register,
 		handleSubmit,
 		formState: { errors },
+		setValue,
 	} = useForm<FormData>({});
-	const onSubmit = handleSubmit(d => setData(d));
+	const onSubmit = handleSubmit(d => {
+		console.debug(d);
+		setData(d);
+	});
 
 	return (
 		<div className="pb-4 dark:bg-gray-800">
 			<h2 className="px-4 py-4 text-xl lg:text-left">Compound interest calculator</h2>
 			<form onSubmit={onSubmit} className="flex-col-center w-full overflow-x-hidden px-4">
 				<fieldset className="flex flex-col items-start space-y-6 sm:grid sm:grid-cols-3 sm:gap-6 sm:space-y-0">
-					<Input
-						// customInput={Input}
-						// thousandSeparator={true}
-						label="Existing amount"
-						placeholder="20,000"
-						inputMode="numeric"
-						errorMessage={errors.existingAmount?.message}
+					<NumberFormat
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						customInput={(props: any) => (
+							<Input
+								{...props}
+								label="Existing amount"
+								errorMessage={errors.existingAmount?.message}
+								className="dark:placeholder-gray-600"
+								placeholder="20,000"
+								inputMode="numeric"
+							/>
+						)}
+						thousandSeparator={true}
+						onValueChange={x => setValue('existingAmount', x.floatValue ?? 0)}
 						{...register('existingAmount', { required: 'Please provide your existing amount' })}
 					/>
 					<Input
@@ -65,14 +77,20 @@ const CompoundInterest: FC<CompoundInterestProps> = ({}: CompoundInterestProps) 
 						<SelectOption value="Yearly">Yearly</SelectOption>
 						<SelectOption value="Monthly">Monthly</SelectOption>
 					</Select>
-					<Input
-						// customInput={Input}
-						// thousandSeparator={true}
-						label="Monthly deposit"
-						placeholder="10,000"
-						inputMode="numeric"
-						className="dark:placeholder-gray-600"
-						errorMessage={errors.monthlyDeposit?.message}
+					<NumberFormat
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						customInput={(props: any) => (
+							<Input
+								{...props}
+								label="Monthly deposit"
+								placeholder="10,000"
+								inputMode="numeric"
+								className="dark:placeholder-gray-600"
+								errorMessage={errors.monthlyDeposit?.message}
+							/>
+						)}
+						thousandSeparator={true}
+						onValueChange={x => setValue('monthlyDeposit', x.floatValue ?? 0)}
 						{...register('monthlyDeposit', {
 							required: 'Please provide how much you will deposit each month',
 						})}

--- a/src/features/Navigation.tsx
+++ b/src/features/Navigation.tsx
@@ -7,7 +7,7 @@ const links = [
 		path: '/stocks',
 		text: 'Stocks',
 	},
-	{ path: '/interest', text: 'Compound calculator' },
+	{ path: '/interest', text: 'Interest' },
 ];
 
 const Navigation: React.FC = () => {
@@ -16,11 +16,11 @@ const Navigation: React.FC = () => {
 	return (
 		<nav className="flex flex-col justify-center md:flex-row">
 			<div className="flex items-center">
-				<button className="md:hidden" onClick={() => setIsOpen((x) => !x)}>
+				<button className="md:hidden" onClick={() => setIsOpen(x => !x)}>
 					{isOpen ? <IoCloseOutline size={32} /> : <IoMenuOutline size={32} />}
 				</button>
 				<a href="/">
-					<h1 className="px-4 md:px-0 text-xl uppercase font-sans font-light">Finance tracker</h1>
+					<h1 className="px-4 font-sans text-xl font-light uppercase md:px-0">Finance tracker</h1>
 				</a>
 			</div>
 
@@ -29,9 +29,9 @@ const Navigation: React.FC = () => {
 					isOpen ? 'flex' : 'hidden'
 				} flex-col md:flex md:flex-row md:items-center md:space-x-4 md:pl-8`}
 			>
-				{links.map((x) => (
+				{links.map(x => (
 					<li key={x.path}>
-						<a href={x.path} className="align-middle h-full font-light hover:underline">
+						<a href={x.path} className="h-full align-middle font-light hover:underline">
 							{x.text}
 						</a>
 					</li>

--- a/src/features/user/userApi.ts
+++ b/src/features/user/userApi.ts
@@ -6,5 +6,5 @@ export function getMyUser(): Promise<User> {
 		credentials: 'include',
 	})
 		.then(res => res.json())
-		.catch(err => console.log(err));
+		.catch(err => console.error(err));
 }

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -1,3 +1,8 @@
 export function sleep(ms: number): Promise<void> {
 	return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function allPropertiesAreDefined(obj: any): boolean {
+	return Object.keys(obj).every(key => obj[key] !== undefined);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5700,10 +5700,10 @@ react-dom@^18.1.0:
     loose-envify "^1.1.0"
     scheduler "^0.22.0"
 
-react-hook-form@^7.3.6:
-  version "7.30.0"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.30.0.tgz#c9e2fd54d3627e43bd94bf38ef549df2e80c1371"
-  integrity sha512-DzjiM6o2vtDGNMB9I4yCqW8J21P314SboNG1O0obROkbg7KVS0I7bMtwSdKyapnCPjHgnxc3L7E5PEdISeEUcQ==
+react-hook-form@^7.31.3:
+  version "7.31.3"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.31.3.tgz#b61bafb9a7435f91695351a7a9f714d8c4df0121"
+  integrity sha512-NVZdCWViIWXXXlQ3jxVQH0NuNfwPf8A/0KvuCxrM9qxtP1qYosfR2ZudarziFrVOC7eTUbWbm1T4OyYCwv9oSQ==
 
 react-icons@^4.2.0:
   version "4.3.1"


### PR DESCRIPTION
Storing interest calculator parameters in the url search parameters allows the user to more easily share a calculation with others, or find it again later.

# Commits
- refactor: Split up interest calculator into smaller components
- style: Improved placeholder color for inputs in interest calculator
- fix: Using NumberFormat to properly format currency values entered into the interest calculator
- feat: Storing interest calculator data in url
- feat: Reset button to calculator
