### PR TITLE
Landing and privacy page

### DIFF
--- a/cypress/e2e/LandingPage.cy.ts
+++ b/cypress/e2e/LandingPage.cy.ts
@@ -1,0 +1,61 @@
+import { host } from './constants';
+import * as MockApi from '../mocks/api';
+
+describe('Landing page', () => {
+	it('Renders', () => {
+		cy.visit(`${host}/`);
+		cy.get('h2')
+			.should('have.text', 'Tools to help with your finances')
+			.should('have.class', 'text-center');
+	});
+
+	it('lists the account page in the description', () => {
+		MockApi.account();
+
+		cy.visit(host);
+		cy.get('main ul').within(() => {
+			cy.get('a[href*="accounts"]').click();
+		});
+
+		cy.url().should('include', '/accounts');
+	});
+
+	it('lists the stocks page in the description', () => {
+		MockApi.stock();
+		MockApi.stockTracked();
+
+		cy.visit(host);
+		cy.get('main ul').within(() => {
+			cy.get('a[href*="stocks"]').click();
+		});
+
+		cy.url().should('include', '/stocks');
+	});
+
+	it('lists the interest calculator page in the description', () => {
+		cy.visit(host);
+		cy.get('main ul').within(() => {
+			cy.get('a[href*="interest"]').click();
+		});
+
+		cy.url().should('include', '/interest');
+	});
+
+	it('list the tax calculator page in the description', () => {
+		cy.visit(host);
+		cy.get('main ul').within(() => {
+			cy.get('a[href*="tax"]').click();
+		});
+
+		cy.url().should('include', '/tax');
+	});
+
+	it('list the budget feature in the description', () => {
+		cy.visit(host);
+		cy.get('main ul').within(() => {
+			cy.get('a[href*="budget"]').click();
+		});
+
+		cy.url().should('include', '/budget');
+	});
+});

--- a/cypress/e2e/account.cy.ts
+++ b/cypress/e2e/account.cy.ts
@@ -1,8 +1,8 @@
 import { host } from './constants';
 
-describe('Budget', () => {
+describe('Account overview', () => {
 	it('passes', () => {
-		cy.visit(`${host}/budget`);
+		cy.visit(`${host}/accounts`);
 		cy.get('h2.page-header').should('have.text', 'Budget');
 	});
 });

--- a/cypress/e2e/nav.cy.ts
+++ b/cypress/e2e/nav.cy.ts
@@ -1,6 +1,14 @@
 import { host } from './constants';
 import * as MockApi from '../mocks/api';
 
+const links = [
+	{ text: 'Accounts', path: '/accounts' },
+	{ text: 'Stocks', path: '/stocks' },
+	{ text: 'Interest', path: '/interest' },
+	{ text: 'Tax calculator', path: '/tax' },
+	{ text: 'Budget', path: '/budget' },
+];
+
 describe('Navigation bar', () => {
 	it('links in navigation bar is correct', () => {
 		MockApi.account();
@@ -11,13 +19,6 @@ describe('Navigation bar', () => {
 			.and('have.class', 'uppercase');
 
 		// Check each link exists
-		const links = [
-			{ text: 'Overview', path: '/' },
-			{ text: 'Stocks', path: '/stocks' },
-			{ text: 'Interest', path: '/interest' },
-			{ text: 'Tax calculator', path: '/tax' },
-			{ text: 'Budget', path: '/budget' },
-		];
 		cy.get('nav > ul > li > a').each((link, i) => {
 			cy.wrap(link)
 				.should('have.text', links[i].text)

--- a/cypress/mocks/api.ts
+++ b/cypress/mocks/api.ts
@@ -3,3 +3,11 @@ import { apiUrlWithPath } from '../../src/features/apiBase';
 export function account() {
 	cy.intercept('GET', `${apiUrlWithPath}/account`, {});
 }
+
+export function stockTracked() {
+	cy.intercept('GET', `${apiUrlWithPath}/stock/tracked`, []);
+}
+
+export function stock() {
+	cy.intercept('GET', `${apiUrlWithPath}/stock?*`, []);
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,5 @@
 import 'compiled.css';
+import Footer from 'features/Footer';
 import Header from 'features/Header';
 import Settings from 'features/Settings';
 import type { AppProps } from 'next/app';
@@ -27,10 +28,13 @@ const Layout: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => (
 			<meta name="color-scheme" content="dark light" />
 		</Head>
 		<Settings>
-			<Header />
-			<main className="h-full min-h-screen bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-200">
-				<Component {...pageProps} />
-			</main>
+			<div className="flex min-h-screen flex-col">
+				<Header />
+				<main className="h-full grow bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-200">
+					<Component {...pageProps} />
+				</main>
+				<Footer />
+			</div>
 		</Settings>
 	</>
 );

--- a/pages/accounts.tsx
+++ b/pages/accounts.tsx
@@ -1,0 +1,14 @@
+import SEO from 'components/SEO';
+import AccountOverview from 'features/AccountOverview';
+import React from 'react';
+
+const AccountTracker: React.FC = () => {
+	return (
+		<>
+			<SEO title="Accounts" />
+			<AccountOverview />
+		</>
+	);
+};
+
+export default AccountTracker;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,48 @@
 import React from 'react';
-import AccountOverview from 'features/AccountOverview';
-import SEO from '../src/components/SEO';
+import SEO from 'components/SEO';
+import TextPage from 'components/TextPage';
 
-const AccountTracker: React.FC = () => {
+const Index: React.FC = () => {
 	return (
 		<>
-			<SEO title="Accounts" />
-			<AccountOverview />
+			<SEO title="Finance Tracker" />
+
+			<TextPage>
+				<h2>Tools to help with your finances</h2>
+
+				<p>
+					This page is a collection of difference tools to help track finances
+					and help with different standard calculations that people come across.
+					These has primarely been made for my own use, and are shared here to
+					expand my own development skills, and for whoever else are interested
+					in using these.
+				</p>
+
+				<h3>Features</h3>
+				<ul className="list-disc pl-4">
+					<li>
+						Overview of your money across <a href="/accounts">accounts</a>
+					</li>
+					<li>
+						Track your <a href="/stocks">stock</a> portfolio, with live price
+						updates
+					</li>
+					<li>
+						A rolling <a href="/interest">interest</a> calculator, to help
+						savings calculations over time
+					</li>
+					<li>
+						Calculate post-<a href="/tax">tax</a> income across different
+						countries with different rates and systems
+					</li>
+					<li>
+						Simple <a href="/budget">budget</a> app, with options like setting a
+						certain percentage for savings
+					</li>
+				</ul>
+			</TextPage>
 		</>
 	);
 };
 
-export default AccountTracker;
+export default Index;

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import SEO from 'components/SEO';
+import TextPage from 'components/TextPage';
+
+const Index: React.FC = () => {
+	return (
+		<>
+			<SEO title="Privacy" />
+			<TextPage>
+				<h2>Privacy</h2>
+				<p>
+					Some functionality on this page sends and stores data server side. All
+					of this data is connected to the currently logged in account, and
+					therefore NOT anonymized. Everything sent over the wire is encrypted
+					(TLS) and stored on encrypted disks. However, as this is just a hobby
+					project at the moment, and while I have no plans to (nor never will
+					have) ever share/sell <b>any</b> data, I take no responsibility for
+					stolen or lost data. Use at your <b>own</b> risk.
+				</p>
+				<p>
+					In regards to cookies, only strictly necessary cookies and other data
+					are stored on the client side. This is limited to your authentication
+					cookie (currently only support for Github), and use of local storage
+					to cache any data you enter on this page.
+				</p>
+			</TextPage>
+		</>
+	);
+};
+
+export default Index;

--- a/src/components/SelectCurrency.tsx
+++ b/src/components/SelectCurrency.tsx
@@ -1,6 +1,7 @@
 import { CurrencySymbol } from 'features/Currency/api';
 import SettingsContext from 'features/Settings/context';
 import React, { FC, useCallback, useContext, useId, useState } from 'react';
+import ClientOnly from './ClientOnly';
 
 interface Props {
 	label: string;
@@ -31,24 +32,25 @@ const SelectCurrency: FC<Props> = ({ label, defaultCurrency, onChange }) => {
 	if (!currencyRates) return null;
 
 	return (
-		<>
+		<ClientOnly>
 			<label htmlFor={id} className="space-y-2">
 				<span className="input-label">{label}</span>
 				<select
 					id={id}
 					onChange={onSelection}
 					className="block rounded bg-gray-100 px-4 py-2 text-black shadow dark:bg-gray-700 dark:text-white"
+					value={currency}
 				>
 					{Object.keys(currencyRates.usd)
 						.map(x => x.toUpperCase())
 						.map(key => (
-							<option key={key} value={key} selected={key === currency}>
+							<option key={key} value={key}>
 								{key}
 							</option>
 						))}
 				</select>
 			</label>
-		</>
+		</ClientOnly>
 	);
 };
 

--- a/src/components/TextPage.tsx
+++ b/src/components/TextPage.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const TextPage: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+	<div className="flex justify-center">
+		<div className="text-page flex max-w-prose flex-col items-center justify-center py-4 px-2 md:px-4">
+			{children}
+		</div>
+	</div>
+);
+
+export default TextPage;

--- a/src/features/Footer.tsx
+++ b/src/features/Footer.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Footer = () => (
+	<footer className="flex h-full flex-row-reverse rounded bg-green-900 px-4 pb-4 pt-2 text-gray-300">
+		<a href="/privacy">Privacy and data</a>
+	</footer>
+);
+
+export default Footer;

--- a/src/features/Navigation.tsx
+++ b/src/features/Navigation.tsx
@@ -3,7 +3,7 @@ import { IoCloseOutline, IoMenuOutline } from 'react-icons/io5';
 import Link from 'next/link';
 
 const links = [
-	{ path: '/', text: 'Overview' },
+	{ path: '/accounts', text: 'Accounts' },
 	{
 		path: '/stocks',
 		text: 'Stocks',

--- a/src/features/TaxCalculator/TaxTable.tsx
+++ b/src/features/TaxCalculator/TaxTable.tsx
@@ -70,9 +70,9 @@ const TableBody: React.FC<TableBodyProps> = ({ countries, calculator }) => {
 				return (
 					<tr key={country} className="tax-row">
 						<td>{result.country}</td>
-						<td>{formatCurrency(result.baseSalaryLocal, localCurrency)}</td>
+						<td>{formatCurrency(result.localSalaryGross, localCurrency)}</td>
 						<td className="text-green-700 dark:text-green-400">
-							{formatCurrency(result.afterTax, currency)}
+							{formatCurrency(result.salaryNet, currency)}
 						</td>
 						<td className="text-red-700 dark:text-red-400">
 							{formatCurrency(result.taxes, currency)}
@@ -83,9 +83,9 @@ const TableBody: React.FC<TableBodyProps> = ({ countries, calculator }) => {
 							})}
 						</td>
 						<td>{formatCurrency(result.localSalaryGross, localCurrency)}</td>
-						<td>{formatCurrency(result.localSalary, localCurrency)}</td>
-						<td>{formatCurrency(result.monthlyCash, localCurrency)}</td>
-						<td>{formatCurrency(result.hourlyRate, localCurrency)}</td>
+						<td>{formatCurrency(result.localSalaryNet, localCurrency)}</td>
+						<td>{formatCurrency(result.localMonthlySalaryNet, localCurrency)}</td>
+						<td>{formatCurrency(result.hourlyRateNet, currency)}</td>
 					</tr>
 				);
 			})}
@@ -98,13 +98,13 @@ const TableHeader: React.FC = () => {
 		<thead className="tax-header">
 			<tr>
 				<th>Country</th>
-				<th>Local base salary</th>
+				<th>Local gross salary</th>
 				<th>Net salary</th>
 				<th>Taxes</th>
 				<th>Tax percent</th>
 				<th>Local gross salary</th>
 				<th>Local net salary</th>
-				<th>Net salary (monthly)</th>
+				<th>Local net salary (monthly)</th>
 				<th>Hourly net salary</th>
 			</tr>
 		</thead>
@@ -128,9 +128,6 @@ function getCalculator(
 			};
 			amount = converter(amount);
 		}
-		const salary_per_hour_after_tax =
-			result.after_tax / (options.workdaysPerYear * options.hoursPerDay);
-		const tax_percentage = result.taxes / amount;
 
 		const local_salary_gross = convertToCurrency(
 			amount,
@@ -145,35 +142,39 @@ function getCalculator(
 			system.currency
 		);
 
+		const tax_percentage = result.taxes / amount;
+		const salary_per_hour_after_tax =
+			result.after_tax / (options.workdaysPerYear * options.hoursPerDay);
+
 		return {
 			country: system.country,
-			baseSalary: amount,
-			baseSalaryLocal: convertToCurrency(
-				amount,
+			taxes: result.taxes,
+			taxPercent: tax_percentage,
+			salaryGross: amount,
+			salaryNet: result.after_tax,
+			hourlyRateNet: salary_per_hour_after_tax,
+			localSalaryGross: local_salary_gross,
+			localSalaryNet: local_salary,
+			localMonthlySalaryNet: local_salary / 12,
+			localHourlyRateNet: convertToCurrency(
+				salary_per_hour_after_tax,
 				rates.usd,
 				defaultCurrency,
 				system.currency
 			),
-			taxes: result.taxes,
-			afterTax: result.after_tax,
-			hourlyRate: salary_per_hour_after_tax,
-			taxPercent: tax_percentage,
-			localSalaryGross: local_salary_gross,
-			localSalary: local_salary,
-			monthlyCash: local_salary / 12,
 		};
 	};
 }
 
 interface CalculationResult {
 	country: string;
-	baseSalary: number;
-	baseSalaryLocal: number;
+	salaryGross: number;
 	taxes: number;
-	afterTax: number;
-	hourlyRate: number;
+	salaryNet: number;
+	hourlyRateNet: number;
 	taxPercent: number;
 	localSalaryGross: number;
-	localSalary: number;
-	monthlyCash: number;
+	localSalaryNet: number;
+	localMonthlySalaryNet: number;
+	localHourlyRateNet: number;
 }

--- a/src/features/TaxCalculator/TaxTable.tsx
+++ b/src/features/TaxCalculator/TaxTable.tsx
@@ -96,15 +96,17 @@ const TableBody: React.FC<TableBodyProps> = ({ countries, calculator }) => {
 const TableHeader: React.FC = () => {
 	return (
 		<thead className="tax-header">
-			<th>Country</th>
-			<th>Local base salary</th>
-			<th>Net salary</th>
-			<th>Taxes</th>
-			<th>Tax percent</th>
-			<th>Local gross salary</th>
-			<th>Local net salary</th>
-			<th>Net salary (monthly)</th>
-			<th>Hourly net salary</th>
+			<tr>
+				<th>Country</th>
+				<th>Local base salary</th>
+				<th>Net salary</th>
+				<th>Taxes</th>
+				<th>Tax percent</th>
+				<th>Local gross salary</th>
+				<th>Local net salary</th>
+				<th>Net salary (monthly)</th>
+				<th>Hourly net salary</th>
+			</tr>
 		</thead>
 	);
 };

--- a/src/features/TaxCalculator/index.tsx
+++ b/src/features/TaxCalculator/index.tsx
@@ -14,7 +14,7 @@ const TaxCalculator: React.FC = () => {
 	});
 
 	return (
-		<div className="h-full min-h-screen bg-white dark:bg-gray-800">
+		<div className="h-full bg-white dark:bg-gray-800">
 			<h2 className="px-4 pt-4 text-2xl">Tax calculator</h2>
 
 			<TaxCalculatorContext.Provider value={{ state, dispatch }}>

--- a/src/main.css
+++ b/src/main.css
@@ -27,6 +27,28 @@ input[type='number'] {
 	.page-header {
 		@apply px-4 py-4 text-xl;
 	}
+
+	.text-page {
+		h2,
+		h3 {
+			@apply text-emerald-900 dark:text-emerald-500;
+			@apply pt-4;
+		}
+		h2 {
+			@apply text-center text-2xl;
+		}
+		h3 {
+			@apply text-xl;
+		}
+
+		p {
+			@apply max-w-prose py-2 text-justify;
+		}
+
+		ul li a {
+			@apply text-blue-900 underline dark:text-blue-500;
+		}
+	}
 }
 
 @layer utilities {


### PR DESCRIPTION
Adds a new landing page to show the users first, instead of throwing them directly onto the account overview page, without any data. 
A `privacy` page has also been added, to explain a bit about what data is collected. Mostly as a disclaimer.

Also fixed some bugs around the tax calculator.

## Changelog

- feat: Added landing + privacy page
- fix: Error on first contentfull loading with SSR for tax calculator page
- fix: Some calculations on the tax calculator
- fix: Screen height issue
