### PR TITLE
Fix 415 error when adding and updating account entry

### DIFF
--- a/src/features/apiBase.ts
+++ b/src/features/apiBase.ts
@@ -90,11 +90,11 @@ export function useApiCall<T>(
 				return await fetch(url, {
 					...options,
 
-					// mode: isDevelopment ? 'cors' : 'no-cors',
+					mode: isDevelopment ? 'cors' : undefined,
 					body: body ? JSON.stringify(body) : undefined,
 					headers: {
 						'Content-Type': 'application/json',
-						// ...options?.headers,
+						...options?.headers,
 						Authorization: `Bearer ${accessToken}`,
 					},
 				});

--- a/src/features/apiBase.ts
+++ b/src/features/apiBase.ts
@@ -84,6 +84,8 @@ export function useApiCall<T>(
 	return useCallback(
 		async (body?: unknown) => {
 			try {
+				console.debug(`Fetching: ${url}. Dev? ${isDevelopment}`);
+				console.debug(options);
 				const accessToken = await getAccessTokenSilently();
 				return await fetch(url, {
 					...options,

--- a/src/features/apiBase.ts
+++ b/src/features/apiBase.ts
@@ -90,11 +90,11 @@ export function useApiCall<T>(
 				return await fetch(url, {
 					...options,
 
-					mode: isDevelopment ? 'cors' : 'no-cors',
+					// mode: isDevelopment ? 'cors' : 'no-cors',
 					body: body ? JSON.stringify(body) : undefined,
 					headers: {
 						'Content-Type': 'application/json',
-						...options?.headers,
+						// ...options?.headers,
 						Authorization: `Bearer ${accessToken}`,
 					},
 				});


### PR DESCRIPTION
Browser was sending the wrong content type and not including the access token when hitting the `account/entry` endpoint, getting a 415 response. 

`mode` was being set when calling `fetch` to `no-cors`, which it should not. Now it is just being left to its default value when not running locally.

## Changelog
- debug: Logging
- debug: Remove option from fetch
- fix: Do not set mode when not in development
