### PR TITLE
fix/auth0 missing refresh token

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,6 +7,7 @@ import Settings from 'features/Settings';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import React from 'react';
+import Script from 'next/script';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const onRedirectCallback = (appState: any) => {
@@ -34,14 +35,14 @@ const Layout: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => (
 			<link rel="apple-touch-icon" href="/logo192.png" />
 			<link rel="manifest" href="/manifest.json" />
 			<meta name="color-scheme" content="dark light" />
-			<script
-				async
-				defer
-				data-api="https://plausible.oliverflecke.me/api/event"
-				data-domain="finance.oliverflecke.me"
-				src="https://plausible.oliverflecke.me/js/script.js"
-			></script>
 		</Head>
+		<Script
+			async
+			defer
+			data-api="https://plausible.oliverflecke.me/api/event"
+			data-domain="finance.oliverflecke.me"
+			src="https://plausible.oliverflecke.me/js/script.js"
+		/>
 		<Auth0Provider
 			domain={process.env.NEXT_PUBLIC_DOMAIN ?? ''}
 			clientId={process.env.NEXT_PUBLIC_CLIENT_ID ?? ''}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -48,6 +48,7 @@ const Layout: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => (
 			onRedirectCallback={onRedirectCallback}
 			cacheLocation="localstorage"
 			useRefreshTokens={true}
+			useRefreshTokensFallback={true}
 			authorizationParams={{
 				redirect_uri:
 					typeof window !== 'undefined'

--- a/src/features/apiBase.ts
+++ b/src/features/apiBase.ts
@@ -55,6 +55,7 @@ export function useApi<T>(
 				loading: false,
 			});
 		} catch (error: unknown) {
+			console.error(error);
 			setState({
 				...state,
 				error,


### PR DESCRIPTION
Fix issue with authentication after access token has expired. The application was currently throwing a "missing refresh_token". See https://community.auth0.com/t/auth0-spa-2-x-returning-missing-refresh-token/98999/19 for discussion. 

## Changelog

- fix: Issue with login after token has expired
- refactor: Use next/script
