### PR TITLE
fix: #22 Issue with GBP (and other currency with special symbols) being cleared on blur.

### DIFF
--- a/src/features/AccountOverview/Cell.tsx
+++ b/src/features/AccountOverview/Cell.tsx
@@ -18,6 +18,10 @@ const Cell: FC<CellProps> = ({ account, entry, date }: CellProps) => {
 	const onBlur = useCallback(
 		async (element: React.FormEvent<HTMLTableCellElement>) => {
 			const amount = parseNumber(element.currentTarget.innerText);
+			if (!amount) {
+				return;
+			}
+
 			await updateEntryCallback({
 				date,
 				amount,

--- a/src/features/apiBase.ts
+++ b/src/features/apiBase.ts
@@ -85,8 +85,6 @@ export function useApiCall<T>(
 	return useCallback(
 		async (body?: unknown) => {
 			try {
-				console.debug(`Fetching: ${url}. Dev? ${isDevelopment}`);
-				console.debug(options);
 				const accessToken = await getAccessTokenSilently();
 				return await fetch(url, {
 					...options,

--- a/src/utils/converters.ts
+++ b/src/utils/converters.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 export function parseNumber(value: any): number {
-	return Number.parseFloat(value.toString().replace(/[,a-zA-Z]/g, ''));
+	return Number.parseFloat(value.toString().replace(/[^.\d]/g, ''));
 }
 
 export const currencyFormatter = Intl.NumberFormat(undefined, {


### PR DESCRIPTION
Fixes #22.
Problem was around parsing number from the currency cells, which could not handled the GBP symbol (or $).