### PR TITLE
Fix light mode on budget page + cleanup

### DIFF
--- a/src/components/button/AddButton.tsx
+++ b/src/components/button/AddButton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { IoAddCircleOutline } from 'react-icons/io5';
+
+interface Props {
+	onClick: () => void;
+}
+
+export default function AddButton({ onClick }: Props) {
+	return (
+		<button onClick={onClick} className="flex focus:outline-none">
+			<IoAddCircleOutline
+				size={24}
+				className="text-green-700 dark:text-green-500"
+			/>
+		</button>
+	);
+}

--- a/src/components/button/RemoveButton.tsx
+++ b/src/components/button/RemoveButton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { IoRemoveCircleOutline } from 'react-icons/io5';
+
+interface Props {
+	onClick: () => void;
+}
+
+export default function RemoveButton({ onClick }: Props) {
+	return (
+		<button onClick={onClick} className="flex focus:outline-none">
+			<IoRemoveCircleOutline
+				size={24}
+				className="text-red-700 dark:text-red-500"
+			/>
+		</button>
+	);
+}

--- a/src/features/Budget/AddLine.tsx
+++ b/src/features/Budget/AddLine.tsx
@@ -42,7 +42,10 @@ const AddLine: React.FC<{ add: (item: AddItemToBudgetRequest) => void }> = ({
 							className="btn btn-primary flex items-center space-x-2 align-middle"
 						>
 							<span>Add</span>
-							<IoAddCircleOutline />
+							<IoAddCircleOutline
+								size={24}
+								className="text-green-400 dark:text-green-500"
+							/>
 						</button>
 					</form>
 				</td>

--- a/src/features/Budget/BudgetConfiguration.tsx
+++ b/src/features/Budget/BudgetConfiguration.tsx
@@ -10,12 +10,11 @@ const Configuration: React.FC<{
 	} = useContext(BudgetContext);
 
 	return (
-		<div className="mx-4 mt-2 rounded bg-cyan-400 p-4 dark:bg-cyan-800">
-			{/* <h3 className="pt-4 text-xl">Configuration</h3> */}
+		<div className="mx-4 mt-2 rounded bg-sky-300 p-4 dark:bg-sky-900">
 			<label htmlFor="desired-savings">Desired savings</label>
-			<span className="mx-4 rounded bg-gray-800 py-1 px-2 focus-within:ring-2">
+			<span className="mx-4 rounded bg-slate-200 py-1 px-2 shadow-md focus-within:ring-2 dark:bg-slate-800">
 				<input
-					className="w-12 bg-transparent pr-2 text-right outline-none"
+					className="w-12 bg-transparent pr-2 text-right outline-none dark:placeholder-slate-600"
 					placeholder="15"
 					name="desired-savings"
 					type="number"

--- a/src/features/Budget/BudgetCreate.tsx
+++ b/src/features/Budget/BudgetCreate.tsx
@@ -19,17 +19,23 @@ const BudgetCreate: React.FC<{ onBudgetCreated: () => void }> = ({
 	);
 
 	return (
-		<div className="flex flex-col space-y-4 rounded bg-purple-900 p-4">
-			<h3 className="text-xl">Create new budget</h3>
+		<div className="flex max-w-lg flex-col space-y-2 rounded bg-sky-300 p-4 dark:bg-sky-900">
+			<h3 className="text-lg">New budget</h3>
 			<form
 				onSubmit={handleSubmit(onSubmit)}
-				className="flex flex-row justify-between"
+				className="flex flex-col space-y-4"
 			>
-				<label className="flex flex-row items-baseline space-x-4">
-					<span className="py-2">Title</span>
+				<label className="flex flex-col items-baseline">
+					<span className="text-md text-gray-700 dark:text-gray-100">
+						Title
+					</span>
 					<Input {...register('title')} placeholder="My budget" />
 				</label>
-				<input type="submit" value="Create" className="btn btn-success w-fit" />
+				<input
+					type="submit"
+					value="Create"
+					className="btn btn-success w-full"
+				/>
 			</form>
 		</div>
 	);

--- a/src/features/Budget/BudgetDetails.tsx
+++ b/src/features/Budget/BudgetDetails.tsx
@@ -3,7 +3,7 @@ import { useComputation } from './useComputation';
 import ItemList from './ItemList';
 import MonthAndYearCells from './MonthAndYearCells';
 import { AddItemToBudgetRequest, BudgetWithItems } from './api';
-import { BudgetContext } from './state';
+import { Action, BudgetContext } from './state';
 import { getBackgroundColorValueIndicator } from 'utils/colors';
 
 const BudgetDetails: FC<{
@@ -21,49 +21,15 @@ const BudgetDetails: FC<{
 		remaining,
 	} = useComputation(budget, { savePercent });
 
-	const deleteItem = useCallback(
-		(item_id: string) => {
-			dispatch({ type: 'REMOVE ITEM', budget_id: budget.id, item_id });
-		},
-		[budget.id, dispatch]
-	);
-	const updateItem = useCallback(
-		(item_id: string, item: AddItemToBudgetRequest) => {
-			dispatch({ type: 'EDIT ITEM', item_id, item });
-		},
-		[dispatch]
-	);
-	const addItem = useCallback(
-		(item: AddItemToBudgetRequest) =>
-			dispatch({
-				type: 'ADD INCOME',
-				budget_id: budget.id,
-				item,
-			}),
-		[budget.id, dispatch]
-	);
-	const addExpense = useCallback(
-		(item: AddItemToBudgetRequest) => {
-			item.amount = -item.amount;
-			dispatch({
-				type: 'ADD EXPENSE',
-				budget_id: budget.id,
-				item,
-			});
-		},
-		[budget.id, dispatch]
+	const { deleteItem, updateItem, addItem, addExpense } = useModel(
+		dispatch,
+		budget.id
 	);
 
 	return (
 		<div className="mx-4 pb-8">
 			<table className="w-full border-separate border-spacing-0 overflow-hidden rounded">
-				<thead>
-					<tr className="text-right">
-						<th className="px-2"></th>
-						<th className="px-2">Per month</th>
-						<th className="px-2">Per year</th>
-					</tr>
-				</thead>
+				<Header />
 
 				<ItemList
 					title="Income"
@@ -83,26 +49,86 @@ const BudgetDetails: FC<{
 					updateItem={updateItem}
 				/>
 
-				<tfoot className="bg-sky-300 dark:bg-sky-900">
-					<tr className={getBackgroundColorValueIndicator(total)}>
-						<th className="px-4 py-1 text-left">After monthley expenses</th>
-						<MonthAndYearCells value={total} />
-						<td></td>
-					</tr>
-					<tr>
-						<td className="px-4 py-1 text-left">Savings</td>
-						<MonthAndYearCells value={savings} />
-						<td></td>
-					</tr>
-					<tr className={getBackgroundColorValueIndicator(remaining)}>
-						<th className="px-4 py-1 text-left">Remaining</th>
-						<MonthAndYearCells value={remaining} />
-						<td></td>
-					</tr>
-				</tfoot>
+				<Footer total={total} savings={savings} remaining={remaining} />
 			</table>
 		</div>
 	);
 };
 
 export default BudgetDetails;
+
+const Footer: React.FC<{
+	total: number;
+	savings: number;
+	remaining: number;
+}> = ({ total, savings, remaining }) => (
+	<tfoot className="bg-sky-300 dark:bg-sky-900">
+		<tr className={getBackgroundColorValueIndicator(total)}>
+			<th className="px-4 py-1 text-left">After monthley expenses</th>
+			<MonthAndYearCells value={total} />
+			<td></td>
+		</tr>
+		<tr>
+			<td className="px-4 py-1 text-left">Savings</td>
+			<MonthAndYearCells value={savings} />
+			<td></td>
+		</tr>
+		<tr className={getBackgroundColorValueIndicator(remaining)}>
+			<th className="px-4 py-1 text-left">Remaining</th>
+			<MonthAndYearCells value={remaining} />
+			<td></td>
+		</tr>
+	</tfoot>
+);
+
+const Header = () => (
+	<thead>
+		<tr className="text-right">
+			<th className="px-2"></th>
+			<th className="px-2">Per month</th>
+			<th className="px-2">Per year</th>
+		</tr>
+	</thead>
+);
+
+function useModel(dispatch: (_: Action) => void, budgetId: string) {
+	const deleteItem = useCallback(
+		(item_id: string) => {
+			dispatch({ type: 'REMOVE ITEM', budget_id: budgetId, item_id });
+		},
+		[budgetId, dispatch]
+	);
+	const updateItem = useCallback(
+		(item_id: string, item: AddItemToBudgetRequest) => {
+			dispatch({ type: 'EDIT ITEM', item_id, item });
+		},
+		[dispatch]
+	);
+	const addItem = useCallback(
+		(item: AddItemToBudgetRequest) =>
+			dispatch({
+				type: 'ADD INCOME',
+				budget_id: budgetId,
+				item,
+			}),
+		[budgetId, dispatch]
+	);
+	const addExpense = useCallback(
+		(item: AddItemToBudgetRequest) => {
+			item.amount = -item.amount;
+			dispatch({
+				type: 'ADD EXPENSE',
+				budget_id: budgetId,
+				item,
+			});
+		},
+		[budgetId, dispatch]
+	);
+
+	return {
+		deleteItem,
+		updateItem,
+		addItem,
+		addExpense,
+	};
+}

--- a/src/features/Budget/BudgetDetails.tsx
+++ b/src/features/Budget/BudgetDetails.tsx
@@ -83,17 +83,17 @@ const BudgetDetails: FC<{
 
 				<tfoot>
 					<tr className={getBackgroundColorValueIndicator(total)}>
-						<th>After monthley expenses</th>
+						<th className="text-left">After monthley expenses</th>
 						<MonthAndYearCells value={total} />
 						<td></td>
 					</tr>
 					<tr>
-						<td>Savings</td>
+						<td className="text-left">Savings</td>
 						<MonthAndYearCells value={savings} />
 						<td></td>
 					</tr>
 					<tr className={getBackgroundColorValueIndicator(remaining)}>
-						<th>Remaining</th>
+						<th className="text-left">Remaining</th>
 						<MonthAndYearCells value={remaining} />
 						<td></td>
 					</tr>

--- a/src/features/Budget/BudgetDetails.tsx
+++ b/src/features/Budget/BudgetDetails.tsx
@@ -1,7 +1,6 @@
 import React, { FC, useCallback, useContext } from 'react';
 import { useComputation } from './useComputation';
 import ItemList from './ItemList';
-import AddLine from './AddLine';
 import MonthAndYearCells from './MonthAndYearCells';
 import { AddItemToBudgetRequest, BudgetWithItems } from './api';
 import { BudgetContext } from './state';
@@ -34,15 +33,35 @@ const BudgetDetails: FC<{
 		},
 		[dispatch]
 	);
+	const addItem = useCallback(
+		(item: AddItemToBudgetRequest) =>
+			dispatch({
+				type: 'ADD INCOME',
+				budget_id: budget.id,
+				item,
+			}),
+		[budget.id, dispatch]
+	);
+	const addExpense = useCallback(
+		(item: AddItemToBudgetRequest) => {
+			item.amount = -item.amount;
+			dispatch({
+				type: 'ADD EXPENSE',
+				budget_id: budget.id,
+				item,
+			});
+		},
+		[budget.id, dispatch]
+	);
 
 	return (
 		<div className="mx-4 pb-8">
 			<table className="w-full border-separate border-spacing-0 overflow-hidden rounded">
 				<thead>
-					<tr>
-						<th></th>
-						<th>Per month</th>
-						<th>Per year</th>
+					<tr className="text-right">
+						<th className="px-2"></th>
+						<th className="px-2">Per month</th>
+						<th className="px-2">Per year</th>
 					</tr>
 				</thead>
 
@@ -50,50 +69,33 @@ const BudgetDetails: FC<{
 					title="Income"
 					items={income}
 					total={totalIncome}
+					addItem={addItem}
 					deleteItem={deleteItem}
 					updateItem={updateItem}
-				/>
-				<AddLine
-					add={(item: AddItemToBudgetRequest) =>
-						dispatch({
-							type: 'ADD INCOME',
-							budget_id: budget.id,
-							item,
-						})
-					}
 				/>
 
 				<ItemList
 					title="Expenses"
 					items={expenses}
 					total={totalExpenses}
+					addItem={addExpense}
 					deleteItem={deleteItem}
 					updateItem={updateItem}
 				/>
-				<AddLine
-					add={(item: AddItemToBudgetRequest) => {
-						item.amount = -item.amount;
-						dispatch({
-							type: 'ADD EXPENSE',
-							budget_id: budget.id,
-							item,
-						});
-					}}
-				/>
 
-				<tfoot>
+				<tfoot className="bg-sky-300 dark:bg-sky-900">
 					<tr className={getBackgroundColorValueIndicator(total)}>
-						<th className="text-left">After monthley expenses</th>
+						<th className="px-4 py-1 text-left">After monthley expenses</th>
 						<MonthAndYearCells value={total} />
 						<td></td>
 					</tr>
 					<tr>
-						<td className="text-left">Savings</td>
+						<td className="px-4 py-1 text-left">Savings</td>
 						<MonthAndYearCells value={savings} />
 						<td></td>
 					</tr>
 					<tr className={getBackgroundColorValueIndicator(remaining)}>
-						<th className="text-left">Remaining</th>
+						<th className="px-4 py-1 text-left">Remaining</th>
 						<MonthAndYearCells value={remaining} />
 						<td></td>
 					</tr>

--- a/src/features/Budget/BudgetList.tsx
+++ b/src/features/Budget/BudgetList.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useContext } from 'react';
+import React, { FC, useCallback, useContext, useState } from 'react';
 import DeleteButton from '../../components/DeleteButton';
 import {
 	Budget,
@@ -8,6 +8,8 @@ import {
 } from './api';
 import BudgetCreate from './BudgetCreate';
 import { BudgetContext } from './state';
+import { Modal } from '@oliverflecke/components-react';
+import AddButton from '../../components/button/AddButton';
 
 const BudgetList: React.FC = () => {
 	const { dispatch } = useContext(BudgetContext);
@@ -33,12 +35,12 @@ const BudgetList: React.FC = () => {
 		[budgets, deleteCallback]
 	);
 
+	const [isCreateOpen, setIsCreateOpen] = useState(false);
+
 	return (
 		<>
-			<BudgetCreate onBudgetCreated={budgets.refresh} />
-
-			<div className="bg-cyan-900 p-4">
-				<div className="flex w-full flex-row justify-between space-x-4 px-4 font-bold">
+			<div className="bg-sky-300 p-4 dark:bg-sky-900">
+				<div className="flex w-full flex-row justify-between space-x-4 font-bold text-gray-800 dark:text-gray-300">
 					<span>Title</span>
 					<span>Created at</span>
 					<span></span>
@@ -55,6 +57,12 @@ const BudgetList: React.FC = () => {
 						))}
 					</ul>
 				)}
+				<div className="flex-end flex w-full">
+					<AddButton onClick={() => setIsCreateOpen(true)} />
+				</div>
+				<Modal isOpen={isCreateOpen} onDismiss={() => setIsCreateOpen(false)}>
+					<BudgetCreate onBudgetCreated={budgets.refresh} />
+				</Modal>
 			</div>
 		</>
 	);

--- a/src/features/Budget/ItemList.tsx
+++ b/src/features/Budget/ItemList.tsx
@@ -40,7 +40,7 @@ const ItemList: React.FC<Props> = ({
 		<>
 			<tbody>
 				<tr>
-					<th className="text-left text-xl">{title}</th>
+					<th className="text-left text-xl underline">{title}</th>
 				</tr>
 				{groups.map(group => (
 					<React.Fragment key={group.category}>

--- a/src/features/Budget/ItemList.tsx
+++ b/src/features/Budget/ItemList.tsx
@@ -9,11 +9,15 @@ import { IoCreateOutline } from 'react-icons/io5';
 import EditItem from './EditItem';
 import { Modal } from '@oliverflecke/components-react';
 import { BudgetContext } from './state';
+import AddButton from '../../components/button/AddButton';
+import AddLine from './AddLine';
+import RemoveButton from '../../components/button/RemoveButton';
 
 interface Props {
 	title: string;
 	items: Item[];
 	total: number;
+	addItem: (item: AddItemToBudgetRequest) => void;
 	deleteItem: (id: string) => void;
 	updateItem: (id: string, item: AddItemToBudgetRequest) => void;
 }
@@ -22,6 +26,7 @@ const ItemList: React.FC<Props> = ({
 	title,
 	items,
 	total,
+	addItem,
 	deleteItem,
 	updateItem,
 }) => {
@@ -29,14 +34,15 @@ const ItemList: React.FC<Props> = ({
 		state: { hideItems },
 	} = useContext(BudgetContext);
 	const groups = useMemo(() => Array.from(groupByCategory(items)), [items]);
+	const [addVisible, setAddVisible] = useState(false);
 
 	return (
-		<tbody className="">
-			<tr>
-				<th className="text-left">{title}</th>
-			</tr>
-			{groups.map(group => {
-				return (
+		<>
+			<tbody>
+				<tr>
+					<th className="text-left text-xl">{title}</th>
+				</tr>
+				{groups.map(group => (
 					<React.Fragment key={group.category}>
 						<tr
 							key={group.category}
@@ -66,14 +72,22 @@ const ItemList: React.FC<Props> = ({
 								</tr>
 							))}
 					</React.Fragment>
-				);
-			})}
-			<tr>
-				<th className="text-left">Total</th>
-				<th className="currency">{formatCurrency(total, currency)}</th>
-				<th className="currency">{formatCurrency(12 * total, currency)}</th>
-			</tr>
-		</tbody>
+				))}
+				<tr>
+					<th className="text-left">Total</th>
+					<th className="currency">{formatCurrency(total, currency)}</th>
+					<th className="currency">{formatCurrency(12 * total, currency)}</th>
+					<th className="flex flex-row justify-end pr-4">
+						{addVisible ? (
+							<RemoveButton onClick={() => setAddVisible(false)} />
+						) : (
+							<AddButton onClick={() => setAddVisible(true)} />
+						)}
+					</th>
+				</tr>
+			</tbody>
+			{addVisible && <AddLine add={addItem} />}
+		</>
 	);
 };
 

--- a/src/features/Budget/ItemList.tsx
+++ b/src/features/Budget/ItemList.tsx
@@ -40,8 +40,8 @@ const ItemList: React.FC<Props> = ({
 					<React.Fragment key={group.category}>
 						<tr
 							key={group.category}
-							className={`font-bold text-yellow-600 ${
-								hideItems ? 'odd:bg-slate-700' : ''
+							className={`font-bold text-fuchsia-700 dark:text-fuchsia-500 ${
+								hideItems ? 'odd:bg-slate-200 dark:odd:bg-slate-700' : ''
 							}`}
 						>
 							<th className="px-4 text-left">{group.category}</th>
@@ -52,7 +52,10 @@ const ItemList: React.FC<Props> = ({
 						</tr>
 						{!hideItems &&
 							group.items.map(item => (
-								<tr key={item.name} className="px-8 odd:bg-slate-700">
+								<tr
+									key={item.name}
+									className="px-8 odd:bg-slate-200 dark:odd:bg-slate-700"
+								>
 									<td className="pl-8">{item.name}</td>
 									<MonthAndYearCells value={Math.abs(item.amount)} />
 									<Actions
@@ -66,7 +69,7 @@ const ItemList: React.FC<Props> = ({
 				);
 			})}
 			<tr>
-				<th>Total</th>
+				<th className="text-left">Total</th>
 				<th className="currency">{formatCurrency(total, currency)}</th>
 				<th className="currency">{formatCurrency(12 * total, currency)}</th>
 			</tr>

--- a/src/features/Budget/index.tsx
+++ b/src/features/Budget/index.tsx
@@ -52,8 +52,6 @@ const Budget: React.FC<{
 
 	return (
 		<>
-			<h2 className="page-header">Budget</h2>
-
 			<BudgetContext.Provider value={{ state, dispatch }}>
 				<BudgetList />
 

--- a/src/features/Budget/index.tsx
+++ b/src/features/Budget/index.tsx
@@ -60,7 +60,7 @@ const Budget: React.FC<{
 				<ClientOnly>
 					{state.budget && (
 						<>
-							<h3 className="px-4 pt-6 text-3xl text-orange-700 dark:text-orange-500">
+							<h3 className=" px-4 pt-6 text-3xl text-fuchsia-700 dark:text-fuchsia-600">
 								{state.budget.title}
 							</h3>
 							<Configuration setSavePercent={setSavePercent} />

--- a/src/features/Navigation.tsx
+++ b/src/features/Navigation.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useLayoutEffect, useState } from 'react';
 import { IoCloseOutline, IoMenuOutline } from 'react-icons/io5';
 import Link from 'next/link';
 
@@ -15,6 +15,13 @@ const links = [
 
 const Navigation: React.FC = () => {
 	const [isOpen, setIsOpen] = useState(false);
+	const [path, setPath] = useState('');
+
+	useLayoutEffect(() => {
+		if (typeof window !== 'undefined') {
+			setPath(window.location.pathname);
+		}
+	}, []);
 
 	return (
 		<nav className="flex flex-col justify-center md:flex-row">
@@ -27,22 +34,28 @@ const Navigation: React.FC = () => {
 					{isOpen ? <IoCloseOutline size={32} /> : <IoMenuOutline size={32} />}
 				</button>
 				<Link href="/">
-					<h1 className="px-4 font-sans text-xl font-light uppercase md:px-0">
+					<h1 className="pl-4 pr-3 font-sans text-xl font-extralight uppercase md:px-0">
 						Finance tracker
 					</h1>
 				</Link>
+				<span className="text-md hidden font-sans font-extralight uppercase sm:inline md:hidden">
+					<span className="text-lg">/</span>
+					<span className="px-2">{links.find(x => x.path === path)?.text}</span>
+				</span>
 			</div>
 
 			<ul
 				className={`${
 					isOpen ? 'flex' : 'hidden'
-				} flex-col md:flex md:flex-row md:items-center md:space-x-6 md:pl-8`}
+				} flex-col font-extralight md:flex md:flex-row md:items-center md:space-x-6 md:pl-8`}
 			>
 				{links.map(x => (
 					<li key={x.path}>
 						<a
 							href={x.path}
-							className="h-full align-middle font-light hover:underline"
+							className={`h-full align-middle font-light hover:underline ${
+								x.path === path ? 'underline' : ''
+							}`}
 						>
 							{x.text}
 						</a>

--- a/src/features/Stocks/index.tsx
+++ b/src/features/Stocks/index.tsx
@@ -51,7 +51,6 @@ const Stocks: React.FC = () => {
 
 	return (
 		<StockContext.Provider value={{ state, dispatch }}>
-			<h2 className="page-header">Stocks</h2>
 			<StocksTable stocks={state.stocks} />
 			<StockActionBar />
 		</StockContext.Provider>

--- a/src/features/TaxCalculator/index.tsx
+++ b/src/features/TaxCalculator/index.tsx
@@ -15,8 +15,6 @@ const TaxCalculator: React.FC = () => {
 
 	return (
 		<div className="h-full bg-white dark:bg-gray-800">
-			<h2 className="px-4 pt-4 text-2xl">Tax calculator</h2>
-
 			<TaxCalculatorContext.Provider value={{ state, dispatch }}>
 				<TaxCalculatorInput />
 				<TaxTable />

--- a/src/main.css
+++ b/src/main.css
@@ -84,6 +84,7 @@ input[type='number'] {
 
 	input.budget {
 		@apply rounded py-2 px-2;
+		@apply shadow-md bg-slate-100 dark:bg-slate-700;
 	}
 
 	input.add-item {


### PR DESCRIPTION
Fix light mode and general theme issues on budget page. It is still not perfect, but at least a lot less busy.
Updated the nav bar to include the current active page.

## Changelog 

- style: Fixed color issues on budget page, especially in light mode
- refactor: Moved `AddLine` into `ItemList`
- refactor: Cleaned up code in budget
- style: Navigation bar with breath crumb-ish layout
