### PR TITLE
ci: stop shuttling target/ between build and deploy jobs

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -39,11 +39,6 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm wrangler build
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: finance-api
-          path: finance-api/target
-
   build-openapi:
     runs-on: ubuntu-latest
     defaults:
@@ -70,11 +65,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v3
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: finance-api
-          path: finance-api/target
 
       - uses: cloudflare/wrangler-action@v4
         with:


### PR DESCRIPTION
## Summary
- `wrangler deploy` always reruns the custom `[build]` command in `wrangler.toml` (confirmed no flag skips it, including `--no-bundle`), so the `finance-api/target` artifact hand-off from `build` → `deploy` never let deploy skip a rebuild — it only tried to warm cargo's compile cache.
- Restoring `target/` via `actions/upload-artifact`/`download-artifact` was corrupting build-script binary permissions (e.g. `libc`'s `build_script_build`), causing `Permission denied (os error 13)` during the nightly + `-Z build-std` compile in the `deploy` job.
- Removed the artifact upload/download; `deploy` now builds clean, same as `build` already does successfully.

## Test plan
- [x] Verified locally that `wrangler build`/`wrangler deploy --dry-run` succeed end-to-end for `finance-api` with a correctly-resolved nightly toolchain
- [x] Confirmed via `wrangler deploy --help` and a local test that no flag (`--no-bundle`, etc.) skips the custom `[build]` command
- [ ] Watch this PR's own `build`/`deploy` CI run to confirm the fix