### PR TITLE
chore: enforce a global 24h minimum release age in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
 	"lockFileMaintenance": { "enabled": true },
 	"prConcurrentLimit": 5,
 	"prHourlyLimit": 0,
+	"minimumReleaseAge": "1 day",
 	"packageRules": [
 		{
 			"description": "npm (frontend): group production minor/patch updates into one PR",


### PR DESCRIPTION
## Summary
- `minimumReleaseAge` was only scoped to `matchManagers: ["npm"]` in the previous Renovate migration, so updates from the `mise` manager (e.g. the pnpm version pin in `mise.toml`), `cargo`, and `github-actions` had no cooldown at all and could be proposed the moment a new version was published.
- Adds a top-level `"minimumReleaseAge": "1 day"` as a floor for every manager. npm keeps its existing stricter 2-day (minor/patch) / 7-day (major) rules since those packageRules still take precedence over the global default.

## Test plan
- [x] `renovate-config-validator renovate.json` passes.
- [ ] Confirm on the next Renovate run that non-npm updates (mise/cargo/actions) published within the last 24h are held back until they clear the cooldown.